### PR TITLE
docs: fix small spelling mistakes across documentation

### DIFF
--- a/src/pages/docs/bootstrap-gitops-automation-with-gimlet-cli.md
+++ b/src/pages/docs/bootstrap-gitops-automation-with-gimlet-cli.md
@@ -6,7 +6,7 @@ description: In this guide you will use Gimlet CLI to bootstrap the gitops workf
 In this tutorial you will use the Gimlet CLI to bootstrap the gitops automation. You will also write application manifests to the gitops repository and see them deploy.
 
 {% callout title="Bootstrapping on the Gimlet dashboard" %}
-Gitops bootstrapping happens automatically on the Gimlet dashbaord during environment creation. You can still read this tutorial to know what goes under the hood.
+Gitops bootstrapping happens automatically on the Gimlet dashboard during environment creation. You can still read this tutorial to know what goes under the hood.
 {% /callout %}
 
 ## Prerequisites

--- a/src/pages/docs/ci-integration.md
+++ b/src/pages/docs/ci-integration.md
@@ -110,7 +110,7 @@ The `Gimlet` [Context](https://circleci.com/docs/contexts) holds two environment
 
 For the CI deploy steps to work, you need to provide access to the Gimlet API. You need to set two secrets `GIMLET_SERVER` and `GIMLET_TOKEN`.
 
-- Set `GIMLET_SERVER` to https://gimletd.<<yourcompany.com>>
+- Set `GIMLET_SERVER` to <https://gimletd>.<<yourcompany.com>>
 - Set `GIMLET_TOKEN` to a Gimlet API key
 
 To create a Gimlet API key navigate to _Profile_ > _Create a new user_ in Gimlet and add a user for this integration.
@@ -156,7 +156,7 @@ Gimlet has release policies that are triggered on certain conditions to automati
 
 ### Shipping the artifact only in CI
 
-To configure the Gimlet step in CI to ship a Gimlet artifact but not to trigger a deploy, you can use the reguler Gimlet CI plugins just make sure to not provide any deploy parameters to it:
+To configure the Gimlet step in CI to ship a Gimlet artifact but not to trigger a deploy, you can use the regular Gimlet CI plugins just make sure to not provide any deploy parameters to it:
 
 ```
     - name: 🚢 Gimlet artifact
@@ -166,7 +166,7 @@ To configure the Gimlet step in CI to ship a Gimlet artifact but not to trigger 
         GIMLET_TOKEN: ${{ secrets.GIMLET_TOKEN }}
 ```
 
-With the above config, Gimlet becomes aware of a new releasble softwware version, and can act on release policies.
+With the above config, Gimlet becomes aware of a new releasable software version, and can act on release policies.
 
 ### Set release policies in the Gimlet environment file
 

--- a/src/pages/docs/deploy-a-static-site.md
+++ b/src/pages/docs/deploy-a-static-site.md
@@ -41,8 +41,9 @@ Once you reviewed and merged the application configuration pull request, you wil
 Push the "Deploy" button now and select the application configuration to deploy.
 
 This will open the deploy panel where you can follow the deploy process:
+
 - Kubernetes manifests are generated and written
-- then syncronized to the cluster.
+- then synchronized to the cluster.
 - A deployment shows up on Gimlet's screen.
 
 ![](/deployed3.png)

--- a/src/pages/docs/deploy-your-first-app-to-kubernetes-with-gimlet-cli.md
+++ b/src/pages/docs/deploy-your-first-app-to-kubernetes-with-gimlet-cli.md
@@ -85,9 +85,9 @@ At Gimlet, as a rule of thumb, we use the environment name as namespace. For thi
 
 ## Configure the deployment
 
-Gimlet defaults to the [OneChart Helm chart](/docs/onechart-reference) for web application deployment. It captures the most common usecases of webaplications, so you don't have to maintain your own Helm chart.
+Gimlet defaults to the [OneChart Helm chart](/docs/onechart-reference) for web application deployment. It captures the most common use cases of web applications, so you don't have to maintain your own Helm chart.
 
-To tailor the deployment configuration of your application, you can manualy edit the environment file's `values` section as it is really nothing more than the values.yaml file for Helm charts, but for convenience, Gimlet starts a configuration page with the following command:
+To tailor the deployment configuration of your application, you can manually edit the environment file's `values` section as it is really nothing more than the values.yaml file for Helm charts, but for convenience, Gimlet starts a configuration page with the following command:
 
 ```bash
 gimlet manifest configure -f .gimlet/staging-demo-app.yaml
@@ -106,7 +106,7 @@ As a prerequisite, your CI process already builds a Docker image from your appli
 
 The demo-app uses the Github container registry (ghcr.io) to host the docker image, and uses the repository name as image name. Images are tagged by the hash of the commit that kicked off the CI build
 
-Set the image repository and tag on the configration screen. This tutorial sets `ghcr.io/gimlet-io/demo-app` and `{{ .SHA }}` respectively.
+Set the image repository and tag on the configuration screen. This tutorial sets `ghcr.io/gimlet-io/demo-app` and `{{ .SHA }}` respectively.
 
 ![Step 6 screenshot](https://images.tango.us/public/edited_image_9afb9f33-b1bb-4712-819c-5fd44b94e613.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.5000&fp-z=1.0000&w=1200&mark-w=0.2&mark-pad=0&mark64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmsucG5n&ar=2505%3A675)
 
@@ -127,7 +127,7 @@ With the image name, tag and container port set, the final thing to set is the u
 Gimlet environments are served with wildcard DNS entries, so `$app.$env.yourcompany.com` will be routed to the right application.
 
 1. Set the _Host Name_ according to the naming convention. We set `demo-app.staging.turbopizza.net`
-2. Enable the HTTPS toogle. A certificate from Let's Encrypt will be provisioned for you.
+2. Enable the HTTPS toggle. A certificate from Let's Encrypt will be provisioned for you.
 3. Add an annotation `kubernetes.io/ingress.class: "nginx"` to match your configuration with the right Ingress Controller in your environment.
 4. Add an annotation `cert-manager.io/cluster-issuer:"letsencrypt"` to tell Cert Manager to provision an SSL certificate
 

--- a/src/pages/docs/deploy-your-first-app-to-kubernetes.md
+++ b/src/pages/docs/deploy-your-first-app-to-kubernetes.md
@@ -51,7 +51,7 @@ As a prerequisite, your CI process already builds a Docker image from your appli
 
 The demo-app uses the Github container registry (ghcr.io) to host the docker image, and uses the repository name as image name. Images are tagged by the hash of the commit that kicked off the CI build
 
-Set the image repository and tag on the configration screen. This tutorial sets `ghcr.io/gimlet-io/demo-app` and `{{ .SHA }}` respectively.
+Set the image repository and tag on the configuration screen. This tutorial sets `ghcr.io/gimlet-io/demo-app` and `{{ .SHA }}` respectively.
 
 ![Step 6 screenshot](https://images.tango.us/public/edited_image_9afb9f33-b1bb-4712-819c-5fd44b94e613.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.5000&fp-z=1.0000&w=1200&mark-w=0.2&mark-pad=0&mark64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmsucG5n&ar=2505%3A675)
 
@@ -61,7 +61,7 @@ You can still continue this tutorial, use the CNCF's testing image, `ghcr.io/pod
 
 ### Watch out for the container port
 
-Time to set the port your application is serving traffic on. It is a common mistake that developers not setting the right port in the deployment configuraton and when they try to open the deployed app in the browser, they get a HTTP 503.
+Time to set the port your application is serving traffic on. It is a common mistake that developers not setting the right port in the deployment configuration and when they try to open the deployed app in the browser, they get a HTTP 503.
 
 The demo-app serves traffic on port 9000. Set your own port.
 

--- a/src/pages/docs/deploy-your-first-app.md
+++ b/src/pages/docs/deploy-your-first-app.md
@@ -46,8 +46,9 @@ Push the "Deploy" button now and select the application configuration to deploy.
 ![](/deploy-button.png)
 
 This will open the deploy panel where you can follow the deploy process:
+
 - Kubernetes manifests are generated and written
-- then syncronized to the cluster.
+- then synchronized to the cluster.
 - A deployment shows up on Gimlet's screen.
 
 ![](/deployed.png)

--- a/src/pages/docs/deploy-your-second-app.md
+++ b/src/pages/docs/deploy-your-second-app.md
@@ -42,9 +42,10 @@ Push the "Deploy" button now and select the application configuration to deploy.
 ![](/deploy-button2.png)
 
 This will open the deploy panel where you can follow the deploy process:
+
 - A container image is built.
 - Kubernetes manifests are generated and written
-- then syncronized to the cluster.
+- then synchronized to the cluster.
 - A deployment shows up on Gimlet's screen.
 
 ![](/deployed2.png)

--- a/src/pages/docs/deploying-static-sites.md
+++ b/src/pages/docs/deploying-static-sites.md
@@ -5,13 +5,13 @@ description: "How to deploy static site on Kubernetes by providing only the buil
 
 In this guide you learn how to deploy static websites to Kubernetes with Gimlet.
 
-The approach does not require conatiner image building, and works generally for React, Next.js, Svelte, Vue, Hugo, Eleventy, Mkdocs, Docusaurus, etc. All the frameworks where the build output is a set of static assets: HTML, JS and CSS files
+The approach does not require container image building, and works generally for React, Next.js, Svelte, Vue, Hugo, Eleventy, Mkdocs, Docusaurus, etc. All the frameworks where the build output is a set of static assets: HTML, JS and CSS files
 
 The approach matches how Netlify deploys static applications: you provide the build command, the rest is taken care of.
 
 ## tldr
 
-The following screen shows the requried configuration to deploy a static site:
+The following screen shows the required configuration to deploy a static site:
 
 ![Static site deploy configuration](/static-build.png)
 
@@ -32,14 +32,14 @@ values:
     # !/usr/bin/env bash
     npm install
     npm run build
-  builtAssets: build/ 
+  builtAssets: build/
 ```
 
 ## Creating a manifest
 
 If you use the [deploy button](/docs/deploy-your-first-app) without creating a deployment configuration first, Gimlet will try to [build a container](/docs/container-image-building) image for you with Buildpacks. This approach has limitations, and container image building takes time.
 
-In this guide we show how you can add a static site deployment configuration, so you can skip image building completelly.
+In this guide we show how you can add a static site deployment configuration, so you can skip image building completely.
 
 - Navigate to your repository
 - Make sure you have at least one connected environment

--- a/src/pages/docs/exposing-gimlet-on-a-domain-name.md
+++ b/src/pages/docs/exposing-gimlet-on-a-domain-name.md
@@ -7,7 +7,7 @@ Now that you finished [installing Gimlet](/docs/installation), you will expose i
 
 So far, you accessed Gimlet through a kubectl port-forward. In this section, you can read about how to use a real domain name secured by HTTPS.
 
-If you are evaulating Gimlet locally, you can use a service called Ngrok to expose Gimlet to external parties, like CI platforms.
+If you are evaluating Gimlet locally, you can use a service called Ngrok to expose Gimlet to external parties, like CI platforms.
 
 ## Exposing a local Gimlet with Ngrok
 

--- a/src/pages/docs/gimlet-manifest-reference.md
+++ b/src/pages/docs/gimlet-manifest-reference.md
@@ -123,7 +123,7 @@ In automated workflows, variables that are part of the released artifact are ava
 
 Artifacts are shipped by CI, and each shipper ships
 
-- all CI specific cariables with prefix `GITHUB` and `CIRCLE`
+- all CI specific variables with prefix `GITHUB` and `CIRCLE`
 - all custom variables that you add in the shipper configuration
 - and the default set of variables that are available no matter which shipper you use.
 

--- a/src/pages/docs/gitops-bootstrapping-reference.md
+++ b/src/pages/docs/gitops-bootstrapping-reference.md
@@ -6,7 +6,7 @@ description: On this page you can see all the possible options you can use to bo
 On this page you can see all the possible options you can use to bootstrap the gitops automation with the Gimlet CLI.
 
 {% callout title="Bootstrapping on the Gimlet dashboard" %}
-Gitops bootstrapping happens automatically on the Gimlet dashbaord during environment creation. You can read this page to know what goes under the hood.
+Gitops bootstrapping happens automatically on the Gimlet dashboard during environment creation. You can read this page to know what goes under the hood.
 {% /callout %}
 
 ## Folder per env

--- a/src/pages/docs/how-to-manage-deployment-configs.md
+++ b/src/pages/docs/how-to-manage-deployment-configs.md
@@ -69,9 +69,9 @@ Every time you save the configuration, you can inspect the diff of the environme
 
 ### With Gimlet CLI
 
-Gimlet defaults to the [OneChart Helm chart](/docs/onechart-reference) for web application deployment. It captures the most common usecases of webaplications, so you don't have to maintain your own Helm chart.
+Gimlet defaults to the [OneChart Helm chart](/docs/onechart-reference) for web application deployment. It captures the most common use cases of web applications, so you don't have to maintain your own Helm chart.
 
-To tailor the deployment configuration of your application, you can manualy edit the environment file's `values` section as it is really nothing more than the values.yaml file for Helm charts, but for convenience, Gimlet starts a configuration page with the following command:
+To tailor the deployment configuration of your application, you can manually edit the environment file's `values` section as it is really nothing more than the values.yaml file for Helm charts, but for convenience, Gimlet starts a configuration page with the following command:
 
 ```bash
 gimlet manifest configure -f .gimlet/staging-demo-app.yaml
@@ -90,7 +90,7 @@ Check out our [SANE Helm guide](/concepts/the-sane-helm-guide).
 
 ### Editing manually
 
-To tailor the deployment configuration of your application, you can manualy edit the environment file's `values` section as it is nothing more than the values.yaml file for Helm charts.
+To tailor the deployment configuration of your application, you can manually edit the environment file's `values` section as it is nothing more than the values.yaml file for Helm charts.
 
 For a full reference of configuration options, check the [OneChart reference](/docs/onechart-reference).
 

--- a/src/pages/docs/make-kubernetes-an-application-platform-with-gimlet-cli.md
+++ b/src/pages/docs/make-kubernetes-an-application-platform-with-gimlet-cli.md
@@ -200,7 +200,7 @@ Congratulations, now you've learnt
 - how to install and manage cluster components
 - and you have great tooling to operate your applications.
 
-Once you are confident in your knowledge, you can delete the dummy environment you created in this tutotrial and start applying your knowledge in managing your testing and production environments.
+Once you are confident in your knowledge, you can delete the dummy environment you created in this tutorial and start applying your knowledge in managing your testing and production environments.
 
 To clean up
 

--- a/src/pages/docs/make-kubernetes-an-application-platform.md
+++ b/src/pages/docs/make-kubernetes-an-application-platform.md
@@ -197,7 +197,7 @@ Congratulations, now you've learnt
 - how to install and manage cluster components
 - and you have great tooling to operate your applications.
 
-Once you are confident in your knowledge, you can delete the dummy environment you created in this tutotrial and start applying your knowledge in managing your testing and production environments.
+Once you are confident in your knowledge, you can delete the dummy environment you created in this tutorial and start applying your knowledge in managing your testing and production environments.
 
 To clean up
 

--- a/src/pages/docs/managing-infrastructure-components.md
+++ b/src/pages/docs/managing-infrastructure-components.md
@@ -27,7 +27,7 @@ ingress-nginx-controller-66455d768d-v8pgh        1/1     Running   0            
 
 ## On the command line
 
-### Reconfiguring infrastructure componentes
+### Reconfiguring infrastructure components
 
 When you run `gimlet stack configure` and configure components on the UI, the configuration options are stored in a file
 called `stack.yaml`.

--- a/src/pages/docs/policy-based-releases.md
+++ b/src/pages/docs/policy-based-releases.md
@@ -13,7 +13,7 @@ Gimlet has release policies that are triggered on certain conditions to automati
 
 ## Shipping the artifact only in CI
 
-To configure the Gimlet step in CI to ship a Gimlet artifact but not to trigger a deploy, you can use the reguler Gimlet CI plugins just make sure to not provide any deploy parameters to it:
+To configure the Gimlet step in CI to ship a Gimlet artifact but not to trigger a deploy, you can use the regular Gimlet CI plugins just make sure to not provide any deploy parameters to it:
 
 ```
     - name: 🚢 Gimlet artifact
@@ -23,7 +23,7 @@ To configure the Gimlet step in CI to ship a Gimlet artifact but not to trigger 
         GIMLET_TOKEN: ${{ secrets.GIMLET_TOKEN }}
 ```
 
-With the above config, Gimlet becomes aware of a new releasble softwware version, and can act on release policies.
+With the above config, Gimlet becomes aware of a new releasable software version, and can act on release policies.
 
 ## Set release policies in the Gimlet environment file
 


### PR DESCRIPTION
Noticed a few small typos when reading the docs that wanted to quickly fix :)